### PR TITLE
update the css classes

### DIFF
--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -307,10 +307,10 @@ function UserDropdown({ small }: { small?: boolean }) {
             {!small && (
               <span className="flex flex-grow items-center truncate">
                 <span className="flex-grow truncate text-sm">
-                  <span className="text-emphasis mb-1 block truncate font-medium leading-none">
+                  <span className="text-emphasis mb-1 pb-1 block truncate font-medium leading-none">
                     {user.name || "Nameless User"}
                   </span>
-                  <span className="text-default block truncate font-normal leading-none">
+                  <span className="text-default pb-1 truncate font-normal leading-none">
                     {user.username
                       ? process.env.NEXT_PUBLIC_WEBSITE_URL === "https://cal.com"
                         ? `cal.com/${user.username}`


### PR DESCRIPTION
This PR fixes the issue with lowercase characters such as j,q,y being cut off at the bottom in the user profile section. The bottom section of these characters were previously hidden due to a styling issue.

Fixes https://github.com/GitStartHQ/tech-screen-calcom/pull/1

To fix this issue, I removed the block class and added the pb-1 class to the affected element in the code.

To test this fix, go to the user profile section and check if the bottom part of lowercase characters such as j,q,y are no longer hidden.