### PR TITLE
feat: added dark mode for inline banners

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,13 @@
   "typescript.preferences.importModuleSpecifier": "non-relative",
   "spellright.language": ["en"],
   "spellright.documentTypes": ["markdown", "typescript"],
-  "tailwindCSS.experimental.classRegex": [["cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"]]
+  "tailwindCSS.experimental.classRegex": [
+    [
+      "cva\\(([^)]*)\\)",
+      "[\"'`]([^\"'`]*).*?[\"'`]"
+    ]
+  ],
+  "cSpell.words": [
+    "calcom"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,13 +7,5 @@
   "typescript.preferences.importModuleSpecifier": "non-relative",
   "spellright.language": ["en"],
   "spellright.documentTypes": ["markdown", "typescript"],
-  "tailwindCSS.experimental.classRegex": [
-    [
-      "cva\\(([^)]*)\\)",
-      "[\"'`]([^\"'`]*).*?[\"'`]"
-    ]
-  ],
-  "cSpell.words": [
-    "calcom"
-  ]
+  "tailwindCSS.experimental.classRegex": [["cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"]]
 }

--- a/apps/web/pages/settings/my-account/appearance.tsx
+++ b/apps/web/pages/settings/my-account/appearance.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 
+import { BookingAppearance } from "@calcom/features/settings/BookingAppearance";
 import ThemeLabel from "@calcom/features/settings/ThemeLabel";
 import { getLayout } from "@calcom/features/settings/layouts/SettingsLayout";
 import { APP_NAME } from "@calcom/lib/constants";
@@ -95,6 +96,35 @@ const AppearanceView = () => {
         });
       }}>
       <Meta title={t("appearance")} description={t("appearance_description")} />
+      <BookingAppearance
+        text="Summarise what happened"
+        subText="Describe what can be done about it here."
+        variant="default"
+        action="Action"
+        dismiss="Dismiss"
+      />
+      <BookingAppearance
+        text="Summarise what happened"
+        subText="Describe what can be done about it here."
+        variant="info"
+        action="Action"
+        dismiss="Dismiss"
+      />
+      <BookingAppearance
+        text="Summarise what happened"
+        subText="Describe what can be done about it here."
+        variant="warning"
+        action="Action"
+        dismiss="Dismiss"
+      />
+      <BookingAppearance
+        text="Summarise what happened"
+        subText="Describe what can be done about it here."
+        variant="error"
+        action="Action"
+        dismiss="Dismiss"
+        errs="Optional error output for debugging"
+      />
       <div className="mb-6 flex items-center text-sm">
         <div>
           <p className="text-default font-semibold">{t("theme")}</p>

--- a/packages/features/settings/BookingAppearance.tsx
+++ b/packages/features/settings/BookingAppearance.tsx
@@ -1,0 +1,86 @@
+//import { XIcon } from "@heroicons/react/solid";
+import classNames from "classnames";
+//import { noop } from "lodash";
+import type { ReactNode } from "react";
+
+//import { FiAlertTriangle, FiInfo } from "../icon";
+import { FiInfo } from "@calcom/ui/components/icon";
+
+export type BookingAppearanceProps = {
+  text: string;
+  subText: string;
+  action: string;
+  dismiss: string;
+  variant?: keyof typeof variantClassName;
+  errs?: string;
+  defaultChecked?: boolean;
+  actions?: ReactNode;
+  onClose?: () => void;
+};
+
+const variantClassName = {
+  default: "dark:bg-[#2E2E2E] bg-[#F3F4F6]",
+  info: "dark:bg-[#253985] bg-[#DEE9FC]",
+  warning: "dark:bg-[#73321B] bg-[#FCEED8]",
+  error: "dark:bg-[#752522] bg-[#F9E3E2]",
+};
+
+const infoVariantClassName = {
+  default: "dark:text-[#FCFCFD] text-[#101010]",
+  info: "dark:text-[#F0F6FE] text-[#253985]",
+  warning: "dark:text-[#FCEED8] text-[#73321B]",
+  error: "dark:text-[#F9E3E2] text-[#752522]",
+};
+
+const colorVariantClassName = {
+  default: "dark:text-[#D6D6D6] text-[#374151]",
+  info: "dark:text-[#C4DAFB] text-[#253985]",
+  warning: "dark:text-[#F8D8B0] text-[#73321B]",
+  error: "dark:text-[#F8D8B0] text-[#752522]",
+};
+
+const buttonVariantClassName = {
+  default: "dark:text-[#FCFCFD] text-[#101010",
+  info: "dark:text-[#F0F6FE] text-[#253985]",
+  warning: "dark:text-[#FCEED8] text-[#73321B]",
+  error: "dark:text-[#F9E3E2] text-[#752522]",
+};
+
+export function BookingAppearance(props: BookingAppearanceProps) {
+  const { variant = "default", defaultChecked, text, subText, dismiss, action, errs } = props;
+  return (
+    <div
+      data-testid="banner"
+      defaultChecked={defaultChecked}
+      className={classNames(
+        "mb-10 min-h-[40px] w-full rounded-[6px] p-3 font-sans  ",
+        variantClassName[variant],
+        colorVariantClassName[variant]
+      )}>
+      <div className="flex flex-row items-center justify-between ">
+        <div className="flex gap-[9.33px] ">
+          <div>
+            <FiInfo
+              className={classNames("h-4 w-4 stroke-[2.5px]", infoVariantClassName[variant])}
+              aria-hidden="true"
+            />
+          </div>
+          <div>
+            <p className=" mb-1 text-[14px] font-semibold leading-[16px]">{text}</p>
+            <p className="text-sm font-normal">{subText} </p>
+            <p className=" mt-2 font-mono text-[10px] font-medium leading-[16px]">{errs}</p>
+          </div>
+        </div>
+
+        <div
+          className={classNames(
+            "flex flex-row gap-7 text-[14px] font-medium leading-[16px] ",
+            buttonVariantClassName[variant]
+          )}>
+          <button>{dismiss}</button>
+          <button>{action}</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/features/settings/BookingAppearance.tsx
+++ b/packages/features/settings/BookingAppearance.tsx
@@ -1,11 +1,10 @@
-//import { XIcon } from "@heroicons/react/solid";
 import classNames from "classnames";
-//import { noop } from "lodash";
 import type { ReactNode } from "react";
 
-//import { FiAlertTriangle, FiInfo } from "../icon";
 import { FiInfo } from "@calcom/ui/components/icon";
 
+//The purpose of this component is to give the user an idea of what colors to expect in inline banners in different modes.
+//It is used in the Appearance page
 export type BookingAppearanceProps = {
   text: string;
   subText: string;

--- a/packages/features/settings/BookingAppearance.tsx
+++ b/packages/features/settings/BookingAppearance.tsx
@@ -52,7 +52,7 @@ export function BookingAppearance(props: BookingAppearanceProps) {
       data-testid="banner"
       defaultChecked={defaultChecked}
       className={classNames(
-        "mb-10 min-h-[40px] w-full rounded-[6px] p-3 font-sans  ",
+        "mb-10 min-h-[40px] w-full rounded-[6px] p-3 font-sans",
         variantClassName[variant],
         colorVariantClassName[variant]
       )}>

--- a/packages/features/settings/BookingAppearance.tsx
+++ b/packages/features/settings/BookingAppearance.tsx
@@ -70,7 +70,6 @@ export function BookingAppearance(props: BookingAppearanceProps) {
             <p className=" mt-2 font-mono text-[10px] font-medium leading-[16px]">{errs}</p>
           </div>
         </div>
-
         <div
           className={classNames(
             "flex flex-row gap-7 text-[14px] font-medium leading-[16px] ",

--- a/packages/ui/components/toast/showToast.tsx
+++ b/packages/ui/components/toast/showToast.tsx
@@ -24,11 +24,11 @@ export const SuccessToast = ({ message, toastVisible }: IToast) => (
 export const ErrorToast = ({ message, toastVisible }: IToast) => (
   <div
     className={classNames(
-      "animate-fade-in-up bg-error text-error mb-2 flex h-auto items-center space-x-2 rounded-md p-3 text-sm font-semibold shadow-md rtl:space-x-reverse md:max-w-sm",
+      "animate-fade-in-up mb-2 flex h-auto items-center space-x-2 rounded-md  bg-[#F9E3E2] p-3 text-sm font-semibold text-[#752522]  shadow-md rtl:space-x-reverse dark:bg-[#752522]  dark:text-[#F8D8B0]  md:max-w-sm",
       toastVisible && "animate-fade-in-up"
     )}>
     <span>
-      <FiInfo className="h-4 w-4" />
+      <FiInfo className="h-4 w-4 text-[#752522] dark:text-[#F9E3E2] " />
     </span>
     <p data-testid="toast-error">{message}</p>
   </div>
@@ -37,11 +37,11 @@ export const ErrorToast = ({ message, toastVisible }: IToast) => (
 export const WarningToast = ({ message, toastVisible }: IToast) => (
   <div
     className={classNames(
-      "animate-fade-in-up bg-brand-default text-brand mb-2 flex h-auto items-center space-x-2 rounded-md p-3 text-sm font-semibold shadow-md rtl:space-x-reverse md:max-w-sm",
+      "animate-fade-in-up  mb-2 flex h-auto items-center space-x-2 rounded-md bg-[#FCEED8] p-3 text-sm font-semibold  text-[#73321B] shadow-md rtl:space-x-reverse dark:bg-[#73321B] dark:text-[#FCEED8] md:max-w-sm",
       toastVisible && "animate-fade-in-up"
     )}>
     <span>
-      <FiInfo className="h-4 w-4" />
+      <FiInfo className="h-4 w-4 text-[#73321B] text-[#FCEED8]" />
     </span>
     <p data-testid="toast-warning">{message}</p>
   </div>

--- a/packages/ui/components/toast/showToast.tsx
+++ b/packages/ui/components/toast/showToast.tsx
@@ -24,7 +24,7 @@ export const SuccessToast = ({ message, toastVisible }: IToast) => (
 export const ErrorToast = ({ message, toastVisible }: IToast) => (
   <div
     className={classNames(
-      "animate-fade-in-up bg-error text-error mb-2 flex h-auto items-center space-x-2 rounded-md p-3 text-sm font-semibold  shadow-md rtl:space-x-reverse dark:bg-[#752522]  dark:text-[#F8D8B0]  md:max-w-sm",
+      "animate-fade-in-up bg-error text-error dark:bg-error mb-2 flex h-auto items-center space-x-2 rounded-md p-3 text-sm font-semibold  shadow-md rtl:space-x-reverse  dark:text-[#F8D8B0]  md:max-w-sm",
       toastVisible && "animate-fade-in-up"
     )}>
     <span>
@@ -37,11 +37,11 @@ export const ErrorToast = ({ message, toastVisible }: IToast) => (
 export const WarningToast = ({ message, toastVisible }: IToast) => (
   <div
     className={classNames(
-      "animate-fade-in-up  mb-2 flex h-auto items-center space-x-2 rounded-md bg-[#FCEED8] p-3 text-sm font-semibold  text-[#73321B] shadow-md rtl:space-x-reverse dark:bg-[#73321B] dark:text-[#FCEED8] md:max-w-sm",
+      "animate-fade-in-up bg-attention dark:bg-attention dark:text-attention text-attention  mb-2 flex h-auto items-center space-x-2 rounded-md  p-3 text-sm font-semibold  shadow-md rtl:space-x-reverse  md:max-w-sm",
       toastVisible && "animate-fade-in-up"
     )}>
     <span>
-      <FiInfo className="h-4 w-4 text-[#73321B] text-[#FCEED8]" />
+      <FiInfo className=" text-attention dark:text-attention h-4 w-4 " />
     </span>
     <p data-testid="toast-warning">{message}</p>
   </div>

--- a/packages/ui/components/toast/showToast.tsx
+++ b/packages/ui/components/toast/showToast.tsx
@@ -6,6 +6,28 @@ import { FiCheck, FiInfo } from "../icon";
 type IToast = {
   message: string;
   toastVisible: boolean;
+  variant?: "default" | "info" | "warning" | "error";
+};
+
+const variantClassName = {
+  default: "dark:bg-[#2E2E2E] bg-[#F3F4F6]",
+  info: "dark:bg-[#253985] bg-[#DEE9FC]",
+  warning: "dark:bg-[#73321B] bg-[#FCEED8]",
+  error: "dark:bg-[#752522] bg-[#F9E3E2]",
+};
+
+const infoVariantClassName = {
+  default: "dark:text-[#FCFCFD] text-[#101010]",
+  info: "dark:text-[#F0F6FE] text-[#253985]",
+  warning: "dark:text-[#FCEED8] text-[#73321B]",
+  error: "dark:text-[#F9E3E2] text-[#752522]",
+};
+
+const colorVariantClassName = {
+  default: "dark:text-[#D6D6D6] text-[#374151]",
+  info: "dark:text-[#C4DAFB] text-[#253985]",
+  warning: "dark:text-[#F8D8B0] text-[#73321B]",
+  error: "dark:text-[#F8D8B0] text-[#752522]",
 };
 
 export const SuccessToast = ({ message, toastVisible }: IToast) => (
@@ -24,11 +46,14 @@ export const SuccessToast = ({ message, toastVisible }: IToast) => (
 export const ErrorToast = ({ message, toastVisible }: IToast) => (
   <div
     className={classNames(
-      "animate-fade-in-up bg-error text-error dark:bg-error mb-2 flex h-auto items-center space-x-2 rounded-md p-3 text-sm font-semibold  shadow-md rtl:space-x-reverse  dark:text-[#F8D8B0]  md:max-w-sm",
-      toastVisible && "animate-fade-in-up"
+      "animate-fade-in-up mb-2 flex h-auto items-center space-x-2 rounded-md p-3 text-sm font-semibold  shadow-md rtl:space-x-reverse  dark:text-[#F8D8B0]  md:max-w-sm",
+      toastVisible && "animate-fade-in-up",
+      variantClassName["error"],
+      colorVariantClassName["error"],
+      infoVariantClassName["error"]
     )}>
     <span>
-      <FiInfo className="text-error dark:text-error h-4 w-4 " />
+      <FiInfo className=" h-4 w-4 " />
     </span>
     <p data-testid="toast-error">{message}</p>
   </div>
@@ -38,7 +63,10 @@ export const WarningToast = ({ message, toastVisible }: IToast) => (
   <div
     className={classNames(
       "animate-fade-in-up bg-attention dark:bg-attention dark:text-attention text-attention  mb-2 flex h-auto items-center space-x-2 rounded-md  p-3 text-sm font-semibold  shadow-md rtl:space-x-reverse  md:max-w-sm",
-      toastVisible && "animate-fade-in-up"
+      toastVisible && "animate-fade-in-up",
+      variantClassName["warning"],
+      colorVariantClassName["warning"],
+      infoVariantClassName["warning"]
     )}>
     <span>
       <FiInfo className=" text-attention dark:text-attention h-4 w-4 " />

--- a/packages/ui/components/toast/showToast.tsx
+++ b/packages/ui/components/toast/showToast.tsx
@@ -24,11 +24,11 @@ export const SuccessToast = ({ message, toastVisible }: IToast) => (
 export const ErrorToast = ({ message, toastVisible }: IToast) => (
   <div
     className={classNames(
-      "animate-fade-in-up mb-2 flex h-auto items-center space-x-2 rounded-md  bg-[#F9E3E2] p-3 text-sm font-semibold text-[#752522]  shadow-md rtl:space-x-reverse dark:bg-[#752522]  dark:text-[#F8D8B0]  md:max-w-sm",
+      "animate-fade-in-up bg-error text-error mb-2 flex h-auto items-center space-x-2 rounded-md p-3 text-sm font-semibold  shadow-md rtl:space-x-reverse dark:bg-[#752522]  dark:text-[#F8D8B0]  md:max-w-sm",
       toastVisible && "animate-fade-in-up"
     )}>
     <span>
-      <FiInfo className="h-4 w-4 text-[#752522] dark:text-[#F9E3E2] " />
+      <FiInfo className="text-error dark:text-error h-4 w-4 " />
     </span>
     <p data-testid="toast-error">{message}</p>
   </div>

--- a/packages/ui/components/toast/showToast.tsx
+++ b/packages/ui/components/toast/showToast.tsx
@@ -62,7 +62,7 @@ export const ErrorToast = ({ message, toastVisible }: IToast) => (
 export const WarningToast = ({ message, toastVisible }: IToast) => (
   <div
     className={classNames(
-      "animate-fade-in-up bg-attention dark:bg-attention dark:text-attention text-attention  mb-2 flex h-auto items-center space-x-2 rounded-md  p-3 text-sm font-semibold  shadow-md rtl:space-x-reverse  md:max-w-sm",
+      "animate-fade-in-up bg-attention  mb-2 flex h-auto items-center space-x-2 rounded-md  p-3 text-sm font-semibold  shadow-md rtl:space-x-reverse  md:max-w-sm",
       toastVisible && "animate-fade-in-up",
       variantClassName["warning"],
       colorVariantClassName["warning"],

--- a/packages/ui/components/top-banner/TopBanner.tsx
+++ b/packages/ui/components/top-banner/TopBanner.tsx
@@ -13,9 +13,31 @@ export type TopBannerProps = {
 };
 
 const variantClassName = {
-  default: "bg-gradient-primary",
-  warning: "bg-orange-400",
-  error: "bg-red-400",
+  default: "dark:bg-[#2E2E2E] bg-[#F3F4F6]",
+  info: "dark:bg-[#253985] bg-[#DEE9FC]",
+  warning: "dark:bg-[#73321B] bg-[#FCEED8]",
+  error: "dark:bg-[#752522] bg-[#F9E3E2]",
+};
+
+const infoVariantClassName = {
+  default: "dark:text-[#FCFCFD] text-[#101010]",
+  info: "dark:text-[#F0F6FE] text-[#253985]",
+  warning: "dark:text-[#FCEED8] text-[#73321B]",
+  error: "dark:text-[#F9E3E2] text-[#752522]",
+};
+
+const colorVariantClassName = {
+  default: "dark:text-[#D6D6D6] text-[#374151]",
+  info: "dark:text-[#C4DAFB] text-[#253985]",
+  warning: "dark:text-[#F8D8B0] text-[#73321B]",
+  error: "dark:text-[#F8D8B0] text-[#752522]",
+};
+
+const buttonVariantClassName = {
+  default: "dark:text-[#FCFCFD] text-[#101010",
+  info: "dark:text-[#F0F6FE] text-[#253985]",
+  warning: "dark:text-[#FCEED8] text-[#73321B]",
+  error: "dark:text-[#F9E3E2] text-[#752522]",
 };
 
 export function TopBanner(props: TopBannerProps) {
@@ -25,19 +47,28 @@ export function TopBanner(props: TopBannerProps) {
       data-testid="banner"
       className={classNames(
         "flex min-h-[40px] w-full items-start justify-between gap-8 py-2 px-4 text-center lg:items-center",
-        variantClassName[variant]
+        variantClassName[variant],
+        colorVariantClassName[variant]
       )}>
       <div className="flex flex-1 flex-col items-start justify-center gap-2 p-1 lg:flex-row lg:items-center">
         <p className="text-emphasis flex flex-col items-start justify-center gap-2 text-left font-sans text-sm font-medium leading-4 lg:flex-row lg:items-center">
           {variant === "error" && (
-            <FiAlertTriangle className="text-emphasis h-4 w-4 stroke-[2.5px]" aria-hidden="true" />
+            <FiAlertTriangle
+              className={classNames("text-emphasis h-4 w-4 stroke-[2.5px]", infoVariantClassName[variant])}
+              aria-hidden="true"
+            />
           )}
           {variant === "warning" && (
-            <FiInfo className="text-emphasis h-4 w-4 stroke-[2.5px]" aria-hidden="true" />
+            <FiInfo
+              className={classNames("text-emphasis h-4 w-4 stroke-[2.5px]", infoVariantClassName[variant])}
+              aria-hidden="true"
+            />
           )}
           {text}
         </p>
-        {actions && <div className="text-sm font-medium">{actions}</div>}
+        {actions && (
+          <div className={classNames("text-sm font-medium", buttonVariantClassName[variant])}>{actions}</div>
+        )}
       </div>
       {typeof onClose === "function" && (
         <button

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,6 +33,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@alloc/quick-lru@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@alloc/quick-lru@npm:5.2.0"
+  checksum: bdc35758b552bcf045733ac047fb7f9a07c4678b944c641adfbd41f798b4b91fffd0fdc0df2578d9b0afc7b4d636aa6e110ead5d6281a2adc1ab90efd7f057f8
+  languageName: node
+  linkType: hard
+
 "@ampproject/remapping@npm:^2.1.0":
   version: 2.1.2
   resolution: "@ampproject/remapping@npm:2.1.2"
@@ -4791,7 +4798,7 @@ __metadata:
     strip-markdown: ^5.0.0
     stripe: ^9.16.0
     superjson: 1.9.1
-    tailwindcss: 3.3.1
+    tailwindcss: ^3.3.1
     tailwindcss-radix: ^2.6.0
     ts-jest: ^28.0.8
     ts-node: ^10.9.1
@@ -23676,6 +23683,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-core-module@npm:^2.12.0":
+  version: 2.12.1
+  resolution: "is-core-module@npm:2.12.1"
+  dependencies:
+    has: ^1.0.3
+  checksum: f04ea30533b5e62764e7b2e049d3157dc0abd95ef44275b32489ea2081176ac9746ffb1cdb107445cf1ff0e0dfcad522726ca27c27ece64dadf3795428b8e468
+  languageName: node
+  linkType: hard
+
 "is-core-module@npm:^2.2.0, is-core-module@npm:^2.8.1":
   version: 2.8.1
   resolution: "is-core-module@npm:2.8.1"
@@ -25045,7 +25061,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jiti@npm:^1.17.2":
+"jiti@npm:^1.18.2":
   version: 1.18.2
   resolution: "jiti@npm:1.18.2"
   bin:
@@ -25775,6 +25791,13 @@ __metadata:
   version: 2.0.6
   resolution: "lilconfig@npm:2.0.6"
   checksum: 40a3cd72f103b1be5975f2ac1850810b61d4053e20ab09be8d3aeddfe042187e1ba70b4651a7e70f95efa1642e7dc8b2ae395b317b7d7753b241b43cef7c0f7d
+  languageName: node
+  linkType: hard
+
+"lilconfig@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "lilconfig@npm:2.1.0"
+  checksum: 8549bb352b8192375fed4a74694cd61ad293904eee33f9d4866c2192865c44c4eb35d10782966242634e0cbc1e91fe62b1247f148dc5514918e3a966da7ea117
   languageName: node
   linkType: hard
 
@@ -28169,6 +28192,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nanoid@npm:^3.3.6":
+  version: 3.3.6
+  resolution: "nanoid@npm:3.3.6"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 7d0eda657002738aa5206107bd0580aead6c95c460ef1bdd0b1a87a9c7ae6277ac2e9b945306aaa5b32c6dcb7feaf462d0f552e7f8b5718abfc6ead5c94a71b3
+  languageName: node
+  linkType: hard
+
 "nanomatch@npm:^1.2.9":
   version: 1.2.13
   resolution: "nanomatch@npm:1.2.13"
@@ -30198,6 +30230,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-import@npm:^15.1.0":
+  version: 15.1.0
+  resolution: "postcss-import@npm:15.1.0"
+  dependencies:
+    postcss-value-parser: ^4.0.0
+    read-cache: ^1.0.0
+    resolve: ^1.1.7
+  peerDependencies:
+    postcss: ^8.0.0
+  checksum: 7bd04bd8f0235429009d0022cbf00faebc885de1d017f6d12ccb1b021265882efc9302006ba700af6cab24c46bfa2f3bc590be3f9aee89d064944f171b04e2a3
+  languageName: node
+  linkType: hard
+
 "postcss-js@npm:^4.0.0":
   version: 4.0.0
   resolution: "postcss-js@npm:4.0.0"
@@ -30206,6 +30251,17 @@ __metadata:
   peerDependencies:
     postcss: ^8.3.3
   checksum: 14be8a58670b4c5d037d40f179240a4f736d53530db727e2635638fa296bc4bff18149ca860928398aace422e55d07c9f5729eeccd395340944985199cdc82a5
+  languageName: node
+  linkType: hard
+
+"postcss-js@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "postcss-js@npm:4.0.1"
+  dependencies:
+    camelcase-css: ^2.0.1
+  peerDependencies:
+    postcss: ^8.4.21
+  checksum: 5c1e83efeabeb5a42676193f4357aa9c88f4dc1b3c4a0332c132fe88932b33ea58848186db117cf473049fc233a980356f67db490bd0a7832ccba9d0b3fd3491
   languageName: node
   linkType: hard
 
@@ -30224,6 +30280,24 @@ __metadata:
     ts-node:
       optional: true
   checksum: 1c589504c2d90b1568aecae8238ab993c17dba2c44f848a8f13619ba556d26a1c09644d5e6361b5784e721e94af37b604992f9f3dc0483e687a0cc1cc5029a34
+  languageName: node
+  linkType: hard
+
+"postcss-load-config@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "postcss-load-config@npm:4.0.1"
+  dependencies:
+    lilconfig: ^2.0.5
+    yaml: ^2.1.1
+  peerDependencies:
+    postcss: ">=8.0.9"
+    ts-node: ">=9.0.0"
+  peerDependenciesMeta:
+    postcss:
+      optional: true
+    ts-node:
+      optional: true
+  checksum: b61f890499ed7dcda1e36c20a9582b17d745bad5e2b2c7bc96942465e406bc43ae03f270c08e60d1e29dab1ee50cb26970b5eb20c9aae30e066e20bd607ae4e4
   languageName: node
   linkType: hard
 
@@ -30353,6 +30427,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-nested@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "postcss-nested@npm:6.0.1"
+  dependencies:
+    postcss-selector-parser: ^6.0.11
+  peerDependencies:
+    postcss: ^8.2.14
+  checksum: 7ddb0364cd797de01e38f644879189e0caeb7ea3f78628c933d91cc24f327c56d31269384454fc02ecaf503b44bfa8e08870a7c4cc56b23bc15640e1894523fa
+  languageName: node
+  linkType: hard
+
 "postcss-pseudo-companion-classes@npm:^0.1.1":
   version: 0.1.1
   resolution: "postcss-pseudo-companion-classes@npm:0.1.1"
@@ -30417,7 +30502,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.0.9, postcss@npm:^8.3.11, postcss@npm:^8.4.13, postcss@npm:^8.4.21":
+"postcss@npm:^8.2.15, postcss@npm:^8.4.17, postcss@npm:^8.4.18":
+  version: 8.4.18
+  resolution: "postcss@npm:8.4.18"
+  dependencies:
+    nanoid: ^3.3.4
+    picocolors: ^1.0.0
+    source-map-js: ^1.0.2
+  checksum: 9349fd99849b2e3d2e134ff949b7770ecb12375f352723ce2bcc06167eba3850ea7844c1b191a85cd915d6a396b4e8ee9a5267e6cc5d8d003d0cbc7a97555d39
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.3.11, postcss@npm:^8.4.13, postcss@npm:^8.4.21":
   version: 8.4.21
   resolution: "postcss@npm:8.4.21"
   dependencies:
@@ -30428,14 +30524,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.2.15, postcss@npm:^8.4.17, postcss@npm:^8.4.18":
-  version: 8.4.18
-  resolution: "postcss@npm:8.4.18"
+"postcss@npm:^8.4.23":
+  version: 8.4.24
+  resolution: "postcss@npm:8.4.24"
   dependencies:
-    nanoid: ^3.3.4
+    nanoid: ^3.3.6
     picocolors: ^1.0.0
     source-map-js: ^1.0.2
-  checksum: 9349fd99849b2e3d2e134ff949b7770ecb12375f352723ce2bcc06167eba3850ea7844c1b191a85cd915d6a396b4e8ee9a5267e6cc5d8d003d0cbc7a97555d39
+  checksum: 814e2126dacfea313588eda09cc99a9b4c26ec55c059188aa7a916d20d26d483483106dc5ff9e560731b59f45c5bb91b945dfadc670aed875cc90ddbbf4e787d
   languageName: node
   linkType: hard
 
@@ -32782,6 +32878,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve@npm:^1.22.2":
+  version: 1.22.3
+  resolution: "resolve@npm:1.22.3"
+  dependencies:
+    is-core-module: ^2.12.0
+    path-parse: ^1.0.7
+    supports-preserve-symlinks-flag: ^1.0.0
+  bin:
+    resolve: bin/resolve
+  checksum: fb834b81348428cb545ff1b828a72ea28feb5a97c026a1cf40aa1008352c72811ff4d4e71f2035273dc536dcfcae20c13604ba6283c612d70fa0b6e44519c374
+  languageName: node
+  linkType: hard
+
 "resolve@npm:^2.0.0-next.3":
   version: 2.0.0-next.3
   resolution: "resolve@npm:2.0.0-next.3"
@@ -32815,6 +32924,19 @@ __metadata:
   bin:
     resolve: bin/resolve
   checksum: c79ecaea36c872ee4a79e3db0d3d4160b593f2ca16e031d8283735acd01715a203607e9ded3f91f68899c2937fa0d49390cddbe0fb2852629212f3cda283f4a7
+  languageName: node
+  linkType: hard
+
+"resolve@patch:resolve@^1.22.2#~builtin<compat/resolve>":
+  version: 1.22.3
+  resolution: "resolve@patch:resolve@npm%3A1.22.3#~builtin<compat/resolve>::version=1.22.3&hash=c3c19d"
+  dependencies:
+    is-core-module: ^2.12.0
+    path-parse: ^1.0.7
+    supports-preserve-symlinks-flag: ^1.0.0
+  bin:
+    resolve: bin/resolve
+  checksum: ad59734723b596d0891321c951592ed9015a77ce84907f89c9d9307dd0c06e11a67906a3e628c4cae143d3e44898603478af0ddeb2bba3f229a9373efe342665
   languageName: node
   linkType: hard
 
@@ -34927,10 +35049,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sucrase@npm:^3.29.0":
-  version: 3.31.0
-  resolution: "sucrase@npm:3.31.0"
+"sucrase@npm:^3.32.0":
+  version: 3.32.0
+  resolution: "sucrase@npm:3.32.0"
   dependencies:
+    "@jridgewell/gen-mapping": ^0.3.2
     commander: ^4.0.0
     glob: 7.1.6
     lines-and-columns: ^1.1.6
@@ -34940,7 +35063,7 @@ __metadata:
   bin:
     sucrase: bin/sucrase
     sucrase-node: bin/sucrase-node
-  checksum: 333990b1bca57acc010ae07c763dddfd34f01fd38afe9e53cf43f4a5096bd7a66f924fed65770288fba475f914f3aa5277cc4490ed9e74c50b4cea7f147e9e63
+  checksum: 79f760aef513adcf22b882d43100296a8afa7f307acef3e8803304b763484cf138a3e2cebc498a6791110ab20c7b8deba097f6ce82f812ca8f1723e3440e5c95
   languageName: node
   linkType: hard
 
@@ -35247,43 +35370,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tailwindcss@npm:3.3.1":
-  version: 3.3.1
-  resolution: "tailwindcss@npm:3.3.1"
-  dependencies:
-    arg: ^5.0.2
-    chokidar: ^3.5.3
-    color-name: ^1.1.4
-    didyoumean: ^1.2.2
-    dlv: ^1.1.3
-    fast-glob: ^3.2.12
-    glob-parent: ^6.0.2
-    is-glob: ^4.0.3
-    jiti: ^1.17.2
-    lilconfig: ^2.0.6
-    micromatch: ^4.0.5
-    normalize-path: ^3.0.0
-    object-hash: ^3.0.0
-    picocolors: ^1.0.0
-    postcss: ^8.0.9
-    postcss-import: ^14.1.0
-    postcss-js: ^4.0.0
-    postcss-load-config: ^3.1.4
-    postcss-nested: 6.0.0
-    postcss-selector-parser: ^6.0.11
-    postcss-value-parser: ^4.2.0
-    quick-lru: ^5.1.1
-    resolve: ^1.22.1
-    sucrase: ^3.29.0
-  peerDependencies:
-    postcss: ^8.0.9
-  bin:
-    tailwind: lib/cli.js
-    tailwindcss: lib/cli.js
-  checksum: 966ba175486fb65ef3dd76aa8ec6929ff1d168531843ca7d5faf680b7097c36bf5f9ca385b563cdfdff935bb2bd37ac5998e877491407867503cc129d118bf93
-  languageName: node
-  linkType: hard
-
 "tailwindcss@npm:^3.2.1":
   version: 3.2.1
   resolution: "tailwindcss@npm:3.2.1"
@@ -35317,6 +35403,40 @@ __metadata:
     tailwind: lib/cli.js
     tailwindcss: lib/cli.js
   checksum: 8479f6e469b3ac3146fec5bf4b5ec411f24f481087d9db9a9e16bd5169cfe5f6af082b8fe656bbb8829faa8805765104843f549b08b4ba34e972d0743d0c7e94
+  languageName: node
+  linkType: hard
+
+"tailwindcss@npm:^3.3.1":
+  version: 3.3.2
+  resolution: "tailwindcss@npm:3.3.2"
+  dependencies:
+    "@alloc/quick-lru": ^5.2.0
+    arg: ^5.0.2
+    chokidar: ^3.5.3
+    didyoumean: ^1.2.2
+    dlv: ^1.1.3
+    fast-glob: ^3.2.12
+    glob-parent: ^6.0.2
+    is-glob: ^4.0.3
+    jiti: ^1.18.2
+    lilconfig: ^2.1.0
+    micromatch: ^4.0.5
+    normalize-path: ^3.0.0
+    object-hash: ^3.0.0
+    picocolors: ^1.0.0
+    postcss: ^8.4.23
+    postcss-import: ^15.1.0
+    postcss-js: ^4.0.1
+    postcss-load-config: ^4.0.1
+    postcss-nested: ^6.0.1
+    postcss-selector-parser: ^6.0.11
+    postcss-value-parser: ^4.2.0
+    resolve: ^1.22.2
+    sucrase: ^3.32.0
+  bin:
+    tailwind: lib/cli.js
+    tailwindcss: lib/cli.js
+  checksum: 4897c70e671c885e151f57434d87ccb806f468a11900f028245b351ffbca5245ff0c10ca5dbb6eb4c7c4df3de8a15a05fe08c2aea4b152cb07bee9bb1d8a14a8
   languageName: node
   linkType: hard
 
@@ -38829,6 +38949,13 @@ __metadata:
   version: 1.10.2
   resolution: "yaml@npm:1.10.2"
   checksum: ce4ada136e8a78a0b08dc10b4b900936912d15de59905b2bf415b4d33c63df1d555d23acb2a41b23cf9fb5da41c256441afca3d6509de7247daa062fd2c5ea5f
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.1.1":
+  version: 2.3.1
+  resolution: "yaml@npm:2.3.1"
+  checksum: 2c7bc9a7cd4c9f40d3b0b0a98e370781b68b8b7c4515720869aced2b00d92f5da1762b4ffa947f9e795d6cd6b19f410bd4d15fdd38aca7bd96df59bd9486fb54
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this PR do?
This PR adds the feature of dark mode for the inline banners. I created a booking appearance file where I gave a preview if the different colours of the inline banners according to their variants. I also modified the the top banner components and show toast components
if a user device is in dark mode, then the colours of the inline banners and toast notifications will correspond to dark mode colours. But if the user device is in light mode then it will be in light mode colours

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #9467


<!-- Please provide a loom video for visual changes to speed up reviews-->
 Loom Video: https://www.loom.com/share/843dad9b6f7b41acb7b40003766f1410


**Environment**: Staging(main branch) / Production

## Type of change

<!-- Please delete bullets that are not relevant. -->


- New feature (non-breaking change which adds functionality)


## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

set your device theme to dark them and observe the changes on the appearance page in settings, or from toast notifications, then set to light theme and see corresponding colours

- [ ] Test A
- [ ] Test B

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->


